### PR TITLE
Agent selected location radio button fixed

### DIFF
--- a/depthmapX/UI/AgentAnalysisDlg.ui
+++ b/depthmapX/UI/AgentAnalysisDlg.ui
@@ -25,7 +25,7 @@
    <property name="title">
     <string>Global setup</string>
    </property>
-   <widget class="QWidget" name="">
+   <widget class="QWidget" name="layoutWidget">
     <property name="geometry">
      <rect>
       <x>20</x>
@@ -47,7 +47,7 @@
      </item>
     </layout>
    </widget>
-   <widget class="QWidget" name="">
+   <widget class="QWidget" name="layoutWidget">
     <property name="geometry">
      <rect>
       <x>20</x>
@@ -89,7 +89,7 @@
    <property name="title">
     <string>Agent set parameters</string>
    </property>
-   <widget class="QRadioButton" name="c_release_location">
+   <widget class="QRadioButton" name="c_no_release_location">
     <property name="geometry">
      <rect>
       <x>20</x>
@@ -102,7 +102,7 @@
      <string>Release from any location</string>
     </property>
    </widget>
-   <widget class="QRadioButton" name="c_radio2">
+   <widget class="QRadioButton" name="c_release_location">
     <property name="geometry">
      <rect>
       <x>20</x>
@@ -115,7 +115,7 @@
      <string>Release from selected locations</string>
     </property>
    </widget>
-   <widget class="QWidget" name="">
+   <widget class="QWidget" name="layoutWidget">
     <property name="geometry">
      <rect>
       <x>20</x>
@@ -150,7 +150,7 @@
    <property name="title">
     <string>Agent program parameters</string>
    </property>
-   <widget class="QWidget" name="">
+   <widget class="QWidget" name="layoutWidget">
     <property name="geometry">
      <rect>
       <x>21</x>
@@ -172,7 +172,7 @@
      </item>
     </layout>
    </widget>
-   <widget class="QWidget" name="">
+   <widget class="QWidget" name="layoutWidget">
     <property name="geometry">
      <rect>
       <x>20</x>
@@ -194,7 +194,7 @@
      </item>
     </layout>
    </widget>
-   <widget class="QWidget" name="">
+   <widget class="QWidget" name="layoutWidget">
     <property name="geometry">
      <rect>
       <x>20</x>
@@ -217,7 +217,7 @@
     </layout>
    </widget>
   </widget>
-  <widget class="QWidget" name="">
+  <widget class="QWidget" name="layoutWidget">
    <property name="geometry">
     <rect>
      <x>30</x>
@@ -246,7 +246,7 @@
     </item>
    </layout>
   </widget>
-  <widget class="QWidget" name="">
+  <widget class="QWidget" name="layoutWidget">
    <property name="geometry">
     <rect>
      <x>30</x>
@@ -324,7 +324,7 @@
     </item>
    </layout>
   </widget>
-  <widget class="QWidget" name="">
+  <widget class="QWidget" name="layoutWidget">
    <property name="geometry">
     <rect>
      <x>190</x>


### PR DESCRIPTION
The Agent Analysis dialog has radio buttons to indicate whether or not
to use the selected locations. The radio buttons were working backwards
(i.e., "Release from selected locations" did NOT use the selected locations, but "Release from any location"
DID use the selected locations).
NOTE: the lines that were changed to have name="layoutWidget" were NOT changes I made intentionally, they were made by the QT Designer tool. I changed only the lines 92 and 105.
